### PR TITLE
fix(ci): Added retry with backoff to PR creation against GitHub secondary rate limit

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -119,10 +119,13 @@ then
       exit 1
     fi
 
-    echo "::warning::gh pr create hit GitHub throttling on attempt ${pr_create_attempt}/${PR_CREATE_MAX_ATTEMPTS}; retrying in ${pr_create_delay}s..."
     # Jitter (0..delay/2) so a burst of jobs that failed together do not retry
-    # in lockstep and re-trip the same limit.
-    sleep "$(( pr_create_delay + RANDOM % (pr_create_delay / 2 + 1) ))"
+    # in lockstep and re-trip the same limit; computed once so it is both logged
+    # and slept.
+    pr_jitter=$(( RANDOM % (pr_create_delay / 2 + 1) ))
+    pr_sleep=$(( pr_create_delay + pr_jitter ))
+    echo "::warning::gh pr create hit GitHub throttling on attempt ${pr_create_attempt}/${PR_CREATE_MAX_ATTEMPTS}; retrying in ${pr_sleep}s (base ${pr_create_delay}s + ${pr_jitter}s jitter)..."
+    sleep "$pr_sleep"
     pr_create_attempt=$((pr_create_attempt + 1))
     pr_create_delay=$((pr_create_delay * 2))
   done

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -102,6 +102,16 @@ then
       break
     fi
 
+    # Only retry GitHub throttling. Genuine errors (bad credentials, validation,
+    # missing base branch, ...) never succeed on retry, so fail fast instead of
+    # burning the backoff window. Unrecognised errors also fail fast: no worse
+    # than the pre-retry behaviour, strictly better for the throttling case.
+    if ! printf '%s' "$pr_create_output" | grep -qiE 'submitted too quickly|secondary rate limit|abuse detection|too many requests|rate limit|try again later|retry your request|wait a few minutes'
+    then
+      echo "::error::gh pr create failed with a non-retryable error; not retrying. Error: ${pr_create_output}"
+      exit 1
+    fi
+
     if [ "$pr_create_attempt" -ge "$PR_CREATE_MAX_ATTEMPTS" ]
     then
       echo "::error::gh pr create failed after ${PR_CREATE_MAX_ATTEMPTS} attempts. Last error: ${pr_create_output}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,14 +70,51 @@ then
   git commit --message "$INPUT_TITLE"
   echo "Pushing git commit"
   git push -uf origin HEAD:$INPUT_DESTINATION_HEAD_BRANCH
-  echo "Creating a pull request"
-  gh pr create -t "$INPUT_TITLE" \
-               -b "$INPUT_COMMENT" \
-               -B "$INPUT_DESTINATION_BASE_BRANCH" \
-               -H "$INPUT_DESTINATION_HEAD_BRANCH"
-               #"$PULL_REQUEST_REVIEWERS"
 
-  pr_number=$(gh pr list | grep $INPUT_DESTINATION_HEAD_BRANCH | awk '{print $1}')
+  # Retry gh pr create with exponential backoff. A burst of simultaneous deploy
+  # merges fires many createPullRequest calls from the same identity within
+  # seconds, which GitHub rejects with its secondary rate limit ("was submitted
+  # too quickly"). The branch has already been pushed by this point, so a
+  # non-retried failure silently drops the promotion PR. The CLI output is
+  # captured here so the real error can be reported (and inspected by later logic).
+  PR_CREATE_MAX_ATTEMPTS="${PR_CREATE_MAX_ATTEMPTS:-5}"
+  pr_create_delay="${PR_CREATE_INITIAL_DELAY:-10}"
+  pr_create_attempt=1
+  while true; do
+    echo "Attempt ${pr_create_attempt}/${PR_CREATE_MAX_ATTEMPTS}: creating pull request for '${INPUT_DESTINATION_HEAD_BRANCH}'..."
+    if pr_create_output=$(gh pr create -t "$INPUT_TITLE" \
+                                       -b "$INPUT_COMMENT" \
+                                       -B "$INPUT_DESTINATION_BASE_BRANCH" \
+                                       -H "$INPUT_DESTINATION_HEAD_BRANCH" 2>&1)
+    then
+      echo "$pr_create_output"
+      break
+    fi
+    # Surface the real CLI error (e.g. the secondary-rate-limit message).
+    echo "$pr_create_output"
+
+    # Idempotency: a prior attempt may have created the PR even though the CLI
+    # reported an error. Match by exact --head (not a scan of the default 30-row
+    # list, which can miss the branch in a busy repo) and treat it as success.
+    if gh pr list --head "$INPUT_DESTINATION_HEAD_BRANCH" --state open | grep -q .
+    then
+      echo "A pull request for '${INPUT_DESTINATION_HEAD_BRANCH}' already exists; continuing."
+      break
+    fi
+
+    if [ "$pr_create_attempt" -ge "$PR_CREATE_MAX_ATTEMPTS" ]
+    then
+      echo "::error::gh pr create failed after ${PR_CREATE_MAX_ATTEMPTS} attempts. Last error: ${pr_create_output}"
+      exit 1
+    fi
+
+    echo "gh pr create failed on attempt ${pr_create_attempt}/${PR_CREATE_MAX_ATTEMPTS}; retrying in ${pr_create_delay}s..."
+    sleep "$pr_create_delay"
+    pr_create_attempt=$((pr_create_attempt + 1))
+    pr_create_delay=$((pr_create_delay * 2))
+  done
+
+  pr_number=$(gh pr list --head "$INPUT_DESTINATION_HEAD_BRANCH" --state all | awk 'NR==1{print $1}')
   echo "PR_NUMBER=$pr_number" >> "$GITHUB_OUTPUT"
   echo "PR_NUMBER=$pr_number" >> "$GITHUB_ENV"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -119,7 +119,9 @@ then
     fi
 
     echo "gh pr create failed on attempt ${pr_create_attempt}/${PR_CREATE_MAX_ATTEMPTS}; retrying in ${pr_create_delay}s..."
-    sleep "$pr_create_delay"
+    # Jitter (0..delay/2) so a burst of jobs that failed together do not retry
+    # in lockstep and re-trip the same limit.
+    sleep "$(( pr_create_delay + RANDOM % (pr_create_delay / 2 + 1) ))"
     pr_create_attempt=$((pr_create_attempt + 1))
     pr_create_delay=$((pr_create_delay * 2))
   done

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -88,6 +88,7 @@ then
                                        -H "$INPUT_DESTINATION_HEAD_BRANCH" 2>&1)
     then
       echo "$pr_create_output"
+      echo "::notice::Pull request for '${INPUT_DESTINATION_HEAD_BRANCH}' created on attempt ${pr_create_attempt}/${PR_CREATE_MAX_ATTEMPTS}."
       break
     fi
     # Surface the real CLI error (e.g. the secondary-rate-limit message).
@@ -98,7 +99,7 @@ then
     # list, which can miss the branch in a busy repo) and treat it as success.
     if gh pr list --head "$INPUT_DESTINATION_HEAD_BRANCH" --state open | grep -q .
     then
-      echo "A pull request for '${INPUT_DESTINATION_HEAD_BRANCH}' already exists; continuing."
+      echo "::notice::A pull request for '${INPUT_DESTINATION_HEAD_BRANCH}' already exists; treating as success after ${pr_create_attempt} attempt(s)."
       break
     fi
 
@@ -118,7 +119,7 @@ then
       exit 1
     fi
 
-    echo "gh pr create failed on attempt ${pr_create_attempt}/${PR_CREATE_MAX_ATTEMPTS}; retrying in ${pr_create_delay}s..."
+    echo "::warning::gh pr create hit GitHub throttling on attempt ${pr_create_attempt}/${PR_CREATE_MAX_ATTEMPTS}; retrying in ${pr_create_delay}s..."
     # Jitter (0..delay/2) so a burst of jobs that failed together do not retry
     # in lockstep and re-trip the same limit.
     sleep "$(( pr_create_delay + RANDOM % (pr_create_delay / 2 + 1) ))"
@@ -129,6 +130,11 @@ then
   pr_number=$(gh pr list --head "$INPUT_DESTINATION_HEAD_BRANCH" --state all | awk 'NR==1{print $1}')
   echo "PR_NUMBER=$pr_number" >> "$GITHUB_OUTPUT"
   echo "PR_NUMBER=$pr_number" >> "$GITHUB_ENV"
+
+  if [ -n "$GITHUB_STEP_SUMMARY" ]
+  then
+    echo "PR #${pr_number} (\`${INPUT_DESTINATION_HEAD_BRANCH}\` -> \`${INPUT_DESTINATION_BASE_BRANCH}\`) created after ${pr_create_attempt} attempt(s)." >> "$GITHUB_STEP_SUMMARY"
+  fi
 
 else
   echo "No changes detected"


### PR DESCRIPTION
## Why

When several deployment PRs are merged within seconds of each other, `deploy_prod_int` (and the other deploy flows) invoke this action many times in rapid succession. Each invocation ends in a `gh pr create` from the same `kor-robot` identity, and GitHub's **secondary rate limit** rejects the burst with `GraphQL: was submitted too quickly (createPullRequest)`.

> [!NOTE]
> This is GitHub's **secondary** rate limit, not the primary one:
>
> 1. **Primary rate limit** — the published quota (≈5,000 requests/hour authenticated; a points budget for GraphQL), tracked in `X-RateLimit-*` headers. We are nowhere near it.
> 2. **Secondary rate limit** (formerly "abuse detection") — a separate, behaviour-based guard against bursty/expensive patterns: too many concurrent requests, or too many creations in a short window. It trips *even while the primary quota is barely touched* — exactly what creating a pile of PRs in ~30s does.

The script runs under `set -e` with a single, un-retried `gh pr create`. By that point the branch has **already been pushed**, so the rejection aborts the step *after* the push — silently orphaning the branch and dropping the downstream promotion PR. Nothing surfaces on the source PR, which is why it looks "silent."

**Real incident this fixes:** the `rs-regulatory-messages` `main-17742c1` promotion — PROD-INT … PROD-INT-5 merged in a ~30s window, all five `deploy_prod_int` jobs hit the limit, and **zero** `[PROD-N] <- [PROD-INT-N]` PRs were created (recovered by hand). It also explains the orphan `temp-branch-*` pile-up in the argocd repos.

## What changed (all in `entrypoint.sh`)

1. **Retry with exponential backoff + idempotent `--head` handling** — `gh pr create` is wrapped in a capture-and-retry loop (default 5 attempts, base `10 → 20 → 40 → 80s`). An exact `gh pr list --head <branch>` check treats a PR a prior attempt already created as success (no duplicates), and the `pr_number` lookup was hardened the same way (the old `gh pr list | grep` only scanned the default 30 rows — unsafe in a repo with hundreds of open PRs).
2. **Retry only on GitHub throttling — fail fast on everything else.** The failure output is classified; only throttling signals (`submitted too quickly`, `secondary rate limit`, `abuse detection`, `too many requests`, `rate limit`, …) are retried. Any other error — bad credentials, validation, missing base branch — fails on attempt 1 instead of burning the backoff window. **This guarantees a PR is never blocked in vain.**
3. **Jitter on the backoff** — a random `0..delay/2` is added per attempt so a burst of jobs that failed together stop retrying in lockstep and re-tripping the same limit.
4. **Observability** — the winning attempt count is a `::notice::` on success/already-exists, each retry a `::warning::`, the final give-up a `::error::` (with the last error), and the attempt count is recorded in the job step summary.
5. **Logged the real jittered wait** — the retry warning shows `base + jitter` (e.g. `retrying in 13s (base 10s + 3s jitter)`).

## Behaviour matrix

| Situation | Before this PR | After |
|---|---|---|
| Normal (no throttle) | 1 `gh pr create` | identical — 1 call, +1 log line |
| Throttled burst | drops PR silently | retries with jittered backoff → succeeds |
| Auth / validation / bad base branch | fails immediately | **still fails immediately** (classified fail-fast) |
| Unrecognised error | fails immediately | fails immediately — *never worse than today* |
| PR already created by a prior attempt | n/a | detected via `--head`, treated as success (no dupe) |

## Design decisions / trade-offs

1. **Why classify instead of "retry everything":** framed as "retry only known throttling, fail fast otherwise," the change *cannot regress* — for any error we don't recognise, behaviour is identical to today (fail immediately); for throttling it's strictly better (retry). The classifier matches a broad-but-stable set of throttling phrases, so the worst case for an unseen phrase is today's behaviour.
2. **Why not lower the backoff factor:** with classification, backoff time is only ever spent on *genuine* throttling, where waiting is correct. Lowering it would just re-hit the limit sooner. Worst-case total wait (~2–4 min across 5 attempts) only happens during a real rate-limit storm; it's zero on the happy path and zero on fail-fast errors.
3. **Runner time:** the longer job lifetime is paid *only* when a retry actually fires (a real throttling burst) — not on normal or failed-fast runs.
4. **Tunable:** `PR_CREATE_MAX_ATTEMPTS` (default 5) and `PR_CREATE_INITIAL_DELAY` (default 10s) via env; defaults need no caller changes.

## Blast radius & rollout

Callers reference this action as `@main` (no pinned tag/SHA), so merging makes the new behaviour live across **every** deploy flow immediately — one merge fixes the fleet, but there's **no staged rollout**. Recommend validating the branch ref before merging (below). The action contract is unchanged — same inputs, same `pr_number` output — so no caller edits are needed.

## Testing

1. `bash -n` — clean on every commit.
2. **Fault-injection harness** (stubbed `gh`/`sleep`, exercises the real loop), all passing:
   1. `S1` success on first try → 1 call, exit 0
   2. `S2` throttled ×2 then succeed → retries, exit 0 (`created on attempt 3/5`)
   3. `S3` throttled, exhaust 5 → exit 1, loud `::error::`
   4. `S4` errored but PR already exists → exit 0, no duplicate
   5. `S5` non-throttling error → **fail fast on attempt 1** (never reaches attempt 2)
3. Recommended before merge: add `shellcheck` to this action's CI; run an integration test by pointing a throwaway workflow at `@fix/pr-create-retry-secondary-rate-limit` doing a no-op promotion into a scratch repo (confirm one PR + the `attempt 1/5` notice). Optional canary: pin one non-prod deploy flow to the branch SHA, watch one real deploy, then merge.

## Out of scope / follow-ups

1. **Root-cause option:** serialize prod-PR creation into a single job rather than the parallel per-merge jobs racing each other (removes the burst at the source). Separate change, not a blocker.
2. **Pre-existing smell:** the script runs `env`, which dumps all env vars (incl. the token) to logs. GitHub masks registered secrets, but it's noise — worth a follow-up, not bundled here.
