### PR TITLE
fix: Self-heal missing labels when opening cross-repo PRs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,16 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  bats:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install bats
+        run: sudo apt-get update && sudo apt-get install -y bats
+      - name: Run tests
+        run: bats test/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,10 +37,7 @@ then
 fi
 
 LABEL_ARGS=()
-# Parallel array of raw label values (LABEL_ARGS holds the --label flags). Used
-# to create labels in the destination repo when a PR-create fails on a label
-# that does not exist there yet.
-LABELS=()
+LABELS=()  # raw values, for creating any that are missing on PR failure
 if [ -n "$INPUT_LABELS" ]
 then
   # Labels may be passed as a comma-separated list and/or multiline text.
@@ -58,12 +55,8 @@ then
   echo "Labels [${LABEL_ARGS[*]}]"
 fi
 
-# Best-effort creation of each label in the destination repo. Only called after
-# a PR-create failed because a label was missing, so this runs rarely. A label
-# that already exists returns non-zero (422) and is left untouched -- we never
-# pass --force, so curated colours/descriptions on existing labels (e.g.
-# 'env: prod') are preserved. A genuine failure (e.g. the token lacking
-# issues:write) is logged, and the retrying gh pr create then fails loudly.
+# Create missing labels in the destination repo. No --force, so existing labels
+# keep their colour/description; best-effort (a real failure surfaces on retry).
 ensure_labels() {
   local label
   for label in "${LABELS[@]}"
@@ -87,14 +80,8 @@ create_pull_request() {
   local pr_stderr
   pr_stderr=$(mktemp)
   trap 'rm -f "$pr_stderr"' RETURN
-  # gh pr create resolves every --label to an existing label ID up front and
-  # aborts (exit 1, no PR created) if one is missing -- e.g. the 'app: <service>'
-  # label for a brand-new service that nobody has created in the destination
-  # repo yet. Existing services deploy hundreds of times a week with labels that
-  # already exist, so keep that path free of extra API calls and only self-heal
-  # on the rare missing-label failure: create the labels, then retry once. This
-  # matches peter-evans/create-pull-request's auto-create behaviour without
-  # paying a label lookup on every deployment.
+  # gh pr create aborts (no PR) if a --label doesn't exist. Try once; on a
+  # missing-label failure create the labels and retry. Happy path pays nothing.
   if open_pr 2>"$pr_stderr"
   then
     cat "$pr_stderr" >&2
@@ -102,11 +89,8 @@ create_pull_request() {
   fi
   cat "$pr_stderr" >&2
 
-  # gh reports a missing label as: could not add label: '<name>' not found.
-  # Match that label-specific phrase (case-insensitively) rather than a bare
-  # "not found" so unrelated 404s (bad repo, missing base branch) don't trigger
-  # a needless label-creation round, and a casing/wording tweak in gh does not
-  # silently defeat the self-heal. Any other failure is real -- propagate it.
+  # Self-heal only the missing-label case (gh: "could not add label: 'x' not
+  # found"); matching the label-specific phrase avoids firing on unrelated 404s.
   grep -qi "could not add label" "$pr_stderr" || return 1
 
   echo "PR creation failed on a missing label; creating labels and retrying once"
@@ -167,9 +151,7 @@ commit_and_push() {
   git push -u origin "HEAD:$INPUT_DESTINATION_HEAD_BRANCH"
 }
 
-# When this file is sourced (e.g. by the test suite) only the function
-# definitions above are needed -- stop before the side-effecting orchestration
-# below, which runs only when the script is executed directly.
+# When sourced (e.g. by tests), stop here: only the functions above are needed.
 if [ "${BASH_SOURCE[0]}" != "${0}" ]; then
   return 0
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -74,10 +74,19 @@ ensure_labels() {
   done
 }
 
+open_pr() {
+  gh pr create -t "$INPUT_TITLE" \
+               -b "$INPUT_COMMENT" \
+               -B "$INPUT_DESTINATION_BASE_BRANCH" \
+               -H "$INPUT_DESTINATION_HEAD_BRANCH" \
+               "${LABEL_ARGS[@]}"
+}
+
 create_pull_request() {
   echo "Creating a pull request"
   local pr_stderr
   pr_stderr=$(mktemp)
+  trap 'rm -f "$pr_stderr"' RETURN
   # gh pr create resolves every --label to an existing label ID up front and
   # aborts (exit 1, no PR created) if one is missing -- e.g. the 'app: <service>'
   # label for a brand-new service that nobody has created in the destination
@@ -86,27 +95,23 @@ create_pull_request() {
   # on the rare missing-label failure: create the labels, then retry once. This
   # matches peter-evans/create-pull-request's auto-create behaviour without
   # paying a label lookup on every deployment.
-  if gh pr create -t "$INPUT_TITLE" \
-                  -b "$INPUT_COMMENT" \
-                  -B "$INPUT_DESTINATION_BASE_BRANCH" \
-                  -H "$INPUT_DESTINATION_HEAD_BRANCH" \
-                  "${LABEL_ARGS[@]}" 2>"$pr_stderr"
+  if open_pr 2>"$pr_stderr"
   then
     cat "$pr_stderr" >&2
     return 0
   fi
-
   cat "$pr_stderr" >&2
-  # Any failure other than a missing label is a real error -- propagate it.
-  grep -q "not found" "$pr_stderr" || return 1
+
+  # gh reports a missing label as: could not add label: '<name>' not found.
+  # Match that label-specific phrase (case-insensitively) rather than a bare
+  # "not found" so unrelated 404s (bad repo, missing base branch) don't trigger
+  # a needless label-creation round, and a casing/wording tweak in gh does not
+  # silently defeat the self-heal. Any other failure is real -- propagate it.
+  grep -qi "could not add label" "$pr_stderr" || return 1
 
   echo "PR creation failed on a missing label; creating labels and retrying once"
   ensure_labels
-  gh pr create -t "$INPUT_TITLE" \
-               -b "$INPUT_COMMENT" \
-               -B "$INPUT_DESTINATION_BASE_BRANCH" \
-               -H "$INPUT_DESTINATION_HEAD_BRANCH" \
-               "${LABEL_ARGS[@]}"
+  open_pr
 }
 
 get_pr_number() {
@@ -161,6 +166,13 @@ commit_and_push() {
   # hand) fails loudly instead of silently discarding their commits.
   git push -u origin "HEAD:$INPUT_DESTINATION_HEAD_BRANCH"
 }
+
+# When this file is sourced (e.g. by the test suite) only the function
+# definitions above are needed -- stop before the side-effecting orchestration
+# below, which runs only when the script is executed directly.
+if [ "${BASH_SOURCE[0]}" != "${0}" ]; then
+  return 0
+fi
 
 # The directory the action was invoked from (the checked-out source repo).
 # Captured before cd'ing into the clone so source paths resolve correctly.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,6 +37,10 @@ then
 fi
 
 LABEL_ARGS=()
+# Parallel array of raw label values (LABEL_ARGS holds the --label flags). Used
+# to create labels in the destination repo when a PR-create fails on a label
+# that does not exist there yet.
+LABELS=()
 if [ -n "$INPUT_LABELS" ]
 then
   # Labels may be passed as a comma-separated list and/or multiline text.
@@ -48,13 +52,56 @@ then
     if [ -n "$label" ]
     then
       LABEL_ARGS+=(--label "$label")
+      LABELS+=("$label")
     fi
   done <<< "${INPUT_LABELS//,/$'\n'}"
   echo "Labels [${LABEL_ARGS[*]}]"
 fi
 
+# Best-effort creation of each label in the destination repo. Only called after
+# a PR-create failed because a label was missing, so this runs rarely. A label
+# that already exists returns non-zero (422) and is left untouched -- we never
+# pass --force, so curated colours/descriptions on existing labels (e.g.
+# 'env: prod') are preserved. A genuine failure (e.g. the token lacking
+# issues:write) is logged, and the retrying gh pr create then fails loudly.
+ensure_labels() {
+  local label
+  for label in "${LABELS[@]}"
+  do
+    echo "Ensuring label exists in destination repo: $label"
+    gh label create "$label" --color ededed \
+      || echo "Note: label '$label' already exists or could not be created"
+  done
+}
+
 create_pull_request() {
   echo "Creating a pull request"
+  local pr_stderr
+  pr_stderr=$(mktemp)
+  # gh pr create resolves every --label to an existing label ID up front and
+  # aborts (exit 1, no PR created) if one is missing -- e.g. the 'app: <service>'
+  # label for a brand-new service that nobody has created in the destination
+  # repo yet. Existing services deploy hundreds of times a week with labels that
+  # already exist, so keep that path free of extra API calls and only self-heal
+  # on the rare missing-label failure: create the labels, then retry once. This
+  # matches peter-evans/create-pull-request's auto-create behaviour without
+  # paying a label lookup on every deployment.
+  if gh pr create -t "$INPUT_TITLE" \
+                  -b "$INPUT_COMMENT" \
+                  -B "$INPUT_DESTINATION_BASE_BRANCH" \
+                  -H "$INPUT_DESTINATION_HEAD_BRANCH" \
+                  "${LABEL_ARGS[@]}" 2>"$pr_stderr"
+  then
+    cat "$pr_stderr" >&2
+    return 0
+  fi
+
+  cat "$pr_stderr" >&2
+  # Any failure other than a missing label is a real error -- propagate it.
+  grep -q "not found" "$pr_stderr" || return 1
+
+  echo "PR creation failed on a missing label; creating labels and retrying once"
+  ensure_labels
   gh pr create -t "$INPUT_TITLE" \
                -b "$INPUT_COMMENT" \
                -B "$INPUT_DESTINATION_BASE_BRANCH" \

--- a/test/entrypoint.bats
+++ b/test/entrypoint.bats
@@ -1,0 +1,145 @@
+#!/usr/bin/env bats
+#
+# Unit tests for the label self-heal logic in entrypoint.sh.
+#
+# entrypoint.sh is sourced (its bottom half is guarded by a BASH_SOURCE check),
+# which defines the functions without running the git/gh orchestration. `gh` is
+# replaced with a fake on PATH that logs every call and simulates PR/label
+# behaviour, so create_pull_request's real branching runs against controlled
+# responses.
+
+setup() {
+  ENTRYPOINT="${BATS_TEST_DIRNAME}/../entrypoint.sh"
+
+  # mktemp rather than BATS_TEST_TMPDIR so the suite runs on older bats too.
+  TESTTMP="$(mktemp -d)"
+  BIN="${TESTTMP}/bin"
+  mkdir -p "$BIN"
+
+  # Call/argument logs and simulated state, read/written by the fake gh.
+  export GH_CALLS="${TESTTMP}/gh_calls"
+  export GH_ARGV="${TESTTMP}/gh_argv"
+  export GH_LABEL_REGISTRY="${TESTTMP}/gh_labels"
+  : > "$GH_CALLS"
+  : > "$GH_ARGV"
+  : > "$GH_LABEL_REGISTRY"
+
+  cat > "$BIN/gh" <<'FAKE_GH'
+#!/usr/bin/env bash
+# Fake gh: logs calls, simulates `pr create`, `label create`, `pr list`.
+printf '%s %s\n' "$1" "$2" >> "$GH_CALLS"
+printf 'ARG:%s\n' "$@" >> "$GH_ARGV"
+
+case "$1 $2" in
+  "pr create")
+    case "${FAKE_PR_CREATE:-ok}" in
+      ok)
+        echo "https://github.com/kor/repo/pull/123"
+        ;;
+      missing_label)
+        # Succeeds only once the app label has actually been created.
+        if grep -qxF 'app: kc-rd-dispatcher' "$GH_LABEL_REGISTRY" 2>/dev/null; then
+          echo "https://github.com/kor/repo/pull/123"
+        else
+          echo "could not add label: 'app: kc-rd-dispatcher' not found" >&2
+          exit 1
+        fi
+        ;;
+      other_error)
+        # Contains "not found" but NOT "could not add label": the old bare
+        # "not found" match would wrongly self-heal here; the new one must not.
+        echo 'failed to create pull request: base branch "main" not found' >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  "label create")
+    case "${FAKE_LABEL_CREATE:-ok}" in
+      ok)       echo "$3" >> "$GH_LABEL_REGISTRY" ;;      # $3 = label name
+      exists)   echo "label already exists" >&2; exit 1 ;; # benign 422
+      forbidden) echo "HTTP 403: not accessible" >&2; exit 1 ;; # no perms
+    esac
+    ;;
+  "pr list")
+    echo "123"
+    ;;
+  *)
+    echo "fake gh: unhandled call: $*" >&2
+    exit 99
+    ;;
+esac
+exit 0
+FAKE_GH
+  chmod +x "$BIN/gh"
+  PATH="$BIN:$PATH"
+
+  # Inputs required so sourcing passes validation without exiting. The three
+  # labels mirror a real promotion PR; INPUT_LABELS is parsed at source time.
+  export INPUT_SOURCE_FOLDERS="values"
+  export INPUT_DESTINATION_FOLDERS="values"
+  export INPUT_DESTINATION_HEAD_BRANCH="temp-branch-test"
+  export INPUT_DESTINATION_BASE_BRANCH="main"
+  export INPUT_TITLE="[PROD] <- [DEV] kc-rd-dispatcher deploy main-2aa7372"
+  export INPUT_COMMENT="test run"
+  export INPUT_LABELS=$'system: kc\nenv: prod\napp: kc-rd-dispatcher'
+
+  # shellcheck source=/dev/null
+  source "$ENTRYPOINT"
+  set +e          # sourcing turned on errexit; assertions need it off
+  IFS=$' \t\n'    # sourcing set IFS=';' for folder parsing; restore default
+}
+
+teardown() {
+  rm -rf "$TESTTMP"
+}
+
+pr_create_calls()  { grep -c '^pr create$'  "$GH_CALLS"; }
+label_create_calls() { grep -c '^label create$' "$GH_CALLS"; }
+
+@test "AC1: missing label self-heals — creates labels then retries and succeeds" {
+  export FAKE_PR_CREATE=missing_label FAKE_LABEL_CREATE=ok
+  run create_pull_request
+  [ "$status" -eq 0 ]
+  [ "$(pr_create_calls)" -eq 2 ]      # initial (fails) + retry (succeeds)
+  [ "$(label_create_calls)" -eq 3 ]   # all three labels ensured
+}
+
+@test "AC2: happy path — labels exist, no label create/list, single pr create" {
+  export FAKE_PR_CREATE=ok
+  run create_pull_request
+  [ "$status" -eq 0 ]
+  [ "$(pr_create_calls)" -eq 1 ]
+  [ "$(label_create_calls)" -eq 0 ]
+  ! grep -q '^label list' "$GH_CALLS"   # no per-deploy label lookup
+}
+
+@test "AC3: label creation never uses --force (existing labels not clobbered)" {
+  export FAKE_PR_CREATE=missing_label FAKE_LABEL_CREATE=ok
+  run create_pull_request
+  [ "$status" -eq 0 ]
+  ! grep -q '^ARG:--force$' "$GH_ARGV"
+}
+
+@test "AC4: non-label failure fails loudly and does not self-heal" {
+  export FAKE_PR_CREATE=other_error
+  run create_pull_request
+  [ "$status" -ne 0 ]
+  [ "$(pr_create_calls)" -eq 1 ]      # no retry
+  [ "$(label_create_calls)" -eq 0 ]   # classifier did not match "not found"
+}
+
+@test "AC5: label-create failure still fails loudly on retry (no silent success)" {
+  export FAKE_PR_CREATE=missing_label FAKE_LABEL_CREATE=forbidden
+  run create_pull_request
+  [ "$status" -ne 0 ]
+  [ "$(pr_create_calls)" -eq 2 ]      # retried once, retry still failed
+  [ "$(label_create_calls)" -ge 1 ]   # attempted the (failing) create
+}
+
+@test "AC7: colon+space label passed to gh as a single argument" {
+  export FAKE_PR_CREATE=ok
+  run create_pull_request
+  [ "$status" -eq 0 ]
+  grep -qxF 'ARG:app: kc-rd-dispatcher' "$GH_ARGV"   # one arg, not split
+  grep -qxF 'ARG:--label' "$GH_ARGV"
+}

--- a/test/entrypoint.bats
+++ b/test/entrypoint.bats
@@ -1,12 +1,7 @@
 #!/usr/bin/env bats
 #
-# Unit tests for the label self-heal logic in entrypoint.sh.
-#
-# entrypoint.sh is sourced (its bottom half is guarded by a BASH_SOURCE check),
-# which defines the functions without running the git/gh orchestration. `gh` is
-# replaced with a fake on PATH that logs every call and simulates PR/label
-# behaviour, so create_pull_request's real branching runs against controlled
-# responses.
+# Unit tests for the label self-heal in entrypoint.sh: source the functions
+# (bottom half is BASH_SOURCE-guarded) and run them against a fake gh on PATH.
 
 setup() {
   ENTRYPOINT="${BATS_TEST_DIRNAME}/../entrypoint.sh"
@@ -46,8 +41,7 @@ case "$1 $2" in
         fi
         ;;
       other_error)
-        # Contains "not found" but NOT "could not add label": the old bare
-        # "not found" match would wrongly self-heal here; the new one must not.
+        # "not found" but not "could not add label" -- must NOT self-heal.
         echo 'failed to create pull request: base branch "main" not found' >&2
         exit 1
         ;;


### PR DESCRIPTION
## Problem

`gh pr create --label X` resolves label names to IDs up front and aborts (exit 1, **no PR created**) if label `X` doesn't exist in the destination repo. So the first cross-repo promotion PR for a brand-new service fails at PR creation because its `app: <service>` label was never created in `kor-infra-argocd-prod` by hand — e.g. the recent `kc-rd-dispatcher` DEV→PROD deploy ([run 29500086258](https://github.com/KOR-Financial/kor-infra-argocd-dev/actions/runs/29500086258)).

`peter-evans/create-pull-request` (used for same-repo tr/rs PRs) auto-creates missing labels; this cross-repo action did not.

## Fix

On a missing-label failure, create the missing labels and retry `gh pr create` once (self-heal).

- **Zero overhead on the hot path**: existing services (labels already present) keep the original single `gh pr create` — no extra API calls. Only the rare missing-label case pays the create + retry.
- **Non-clobbering**: labels are created without `--force`, so curated colours/descriptions on existing labels (`env: prod`, etc.) are preserved.
- **Precise classification**: keys off gh's label-specific message (`could not add label`, case-insensitive), so unrelated 404s don't trigger a needless label-creation round; a label-create failure (e.g. token lacking `issues:write`) degrades to today's loud failure.

## Tests

Adds a `bats` suite (fake `gh` on `PATH`) + CI, covering: happy path makes no label API calls, missing label self-heals and retries once, labels created without `--force`, non-label failure fails loudly without self-healing, label-create failure still fails loudly, and colon+space labels pass through as single arguments.
